### PR TITLE
readme me accuracy

### DIFF
--- a/chef/cookbooks/cpe_hosts/README.md
+++ b/chef/cookbooks/cpe_hosts/README.md
@@ -1,7 +1,6 @@
 cpe_hosts Cookbook
 ----------------
-This cookbook mananges hosts in the /etc/hosts file between the
-tags `#Start-Managed-CPE-Hosts` and `#End-Managed-CPE-Hosts`.
+This cookbook mananges hosts in the /etc/hosts file which have the following tag: ` # Chef Managed`
 
 Attributes
 ----------


### PR DESCRIPTION
Updating readme to reflect what actually happens in the cpe_hosts resource. I'm guessing this was just a mismatch between your internal chef repo and the public facing one.